### PR TITLE
Adding initial data model and Sequelize ORM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # production
 /build
+/db/config/config.js
 
 # misc
 .DS_Store

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,7 @@
+const path = require('path');
+module.exports = {
+  'config': path.resolve('db/config', 'config.js'),
+  'models-path': path.resolve('db', 'models'),
+  'seeders-path': path.resolve('db', 'seeders'),
+  'migrations-path': path.resolve('db', 'migrations')
+};

--- a/db/config/config.example.js
+++ b/db/config/config.example.js
@@ -1,0 +1,25 @@
+"use strict"
+
+module.exports = {
+  development: {
+    username: "factorio",
+    password: null,
+    database: "factorio_builds_dev",
+    host: "127.0.0.1",
+    dialect: "postgres",
+  },
+  test: {
+    username: "factorio",
+    password: null,
+    database: "factorio_builds_test",
+    host: "127.0.0.1",
+    dialect: "postgres",
+  },
+  production: {
+    username: "root",
+    password: null,
+    database: "factorio_builds_prod",
+    host: "127.0.0.1",
+    dialect: "postgres",
+  },
+}

--- a/db/migrations/20200922125001-create-users.js
+++ b/db/migrations/20200922125001-create-users.js
@@ -1,0 +1,29 @@
+"use strict"
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("users", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        field: "created_at",
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        field: "updated_at",
+      },
+    })
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("users")
+  },
+}

--- a/db/migrations/20200922125225-create-builds.js
+++ b/db/migrations/20200922125225-create-builds.js
@@ -1,0 +1,49 @@
+"use strict"
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("builds", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      ownerId: {
+        type: Sequelize.UUID,
+        references: {
+          model: "users",
+          key: "id",
+        },
+        onUpdate: "cascade",
+        onDelete: "set null",
+        field: "owner_id",
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      blueprint: {
+        type: Sequelize.TEXT,
+      },
+      blueprintJson: {
+        type: Sequelize.JSONB,
+        field: "json",
+      },
+      metadata: {
+        type: Sequelize.JSONB,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        field: "created_at",
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        field: "updated_at",
+      },
+    })
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("builds")
+  },
+}

--- a/db/models/builds.js
+++ b/db/models/builds.js
@@ -1,0 +1,33 @@
+"use strict"
+const { Model } = require("sequelize")
+const { users } = require("./users")
+
+module.exports = (sequelize, DataTypes) => {
+  class builds extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+      console.dir(models)
+    }
+  }
+  builds.init(
+    {
+      name: DataTypes.STRING,
+      ownerId: DataTypes.UUID,
+      blueprint: DataTypes.TEXT,
+      blueprintJson: DataTypes.JSONB,
+      metadata: DataTypes.JSONB,
+    },
+    {
+      sequelize,
+      modelName: "builds",
+    }
+  )
+
+  builds.belongsTo(users)
+  return builds
+}

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require(__dirname + '/../config/config.js')[env];
+const db = {};
+
+let sequelize;
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.database, config.username, config.password, config);
+}
+
+fs
+  .readdirSync(__dirname)
+  .filter(file => {
+    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+  })
+  .forEach(file => {
+    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;

--- a/db/models/users.js
+++ b/db/models/users.js
@@ -1,0 +1,23 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class users extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  };
+  users.init({
+    name: DataTypes.STRING
+  }, {
+    sequelize,
+    modelName: 'users',
+  });
+  return users;
+};

--- a/db/seeders/20200922125006-users.js
+++ b/db/seeders/20200922125006-users.js
@@ -1,0 +1,44 @@
+"use strict"
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add seed commands here.
+     *
+     * Example:
+     * await queryInterface.bulkInsert('People', [{
+     *   name: 'John Doe',
+     *   isBetaMember: false
+     * }], {});
+     */
+
+    await queryInterface.bulkInsert(
+      "users",
+      [
+        {
+          name: "Billy Bob",
+          id: "c8b15803-1b90-4194-9896-a2869e67deb2",
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          name: "Mary Sue",
+          id: "8358cfb0-2675-4651-a9c2-0d7cf57d6110",
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+      {}
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add commands to revert seed here.
+     *
+     * Example:
+     * await queryInterface.bulkDelete('People', null, {});
+     */
+    await queryInterface.bulkDelete("users", null, {})
+  },
+}

--- a/db/seeders/20200922125247-builds.js
+++ b/db/seeders/20200922125247-builds.js
@@ -1,0 +1,63 @@
+"use strict"
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add seed commands here.
+     *
+     * Example:
+     * await queryInterface.bulkInsert('People', [{
+     *   name: 'John Doe',
+     *   isBetaMember: false
+     * }], {});
+     */
+    await queryInterface.bulkInsert(
+      "builds",
+      [
+        {
+          id: "a197ee1c-9b02-4824-bd5f-3725073fc772",
+          name: "Single Lane Balancer",
+          owner_id: "c8b15803-1b90-4194-9896-a2869e67deb2",
+          blueprint:
+            "0eNrllkFvgyAYhv9Kw1kXsK22HnfuaddlabD91pEpGMCmTeN/H2gbzUqnctmSnQwf8vDy+vHGC8ryCkrJuN5mQnyi9NJVFEpfe0M7x3aCt2XFDpzmtqbPJaAUMQ0FChCnhR3BqZSgVKgl5aoUUocZ5BrVAWJ8DyeUkjoYDVFlzrQG2Vse1W8BAq6ZZtAKagbnLa+KzLyZkiEpASqFMssFt/sbZGiWnM0jMrvsmYRdOxdZod/g0WQ4vrEdtPkdrTKHlAcpzPNnsdhovVonKl1W1uE7/uKxofdc/LRspRKX1KWHVDxeaTzZ186G3ieLHejE32TSSWf8gfLVBI9vFjubYe3ZWmTYAoI97TWtYG5bczfTXh4EKKdmmamR2YZymD3TnPIdyHAD73b6CFI1rGSOyTqOyDyJuyuMrcR/ky7ucIl/IVxG5iAejsGFR9P/kVwZxk8I2MTXY6cXK5+4HpklY489JvI84sQZVdHEcHlhh4/hdCEuatj84/TRuUVnV7QyU9SoOsL2llEPtqm/ACpbH24=",
+          json: JSON.stringify(require("./bp2.json")),
+          metadata: JSON.stringify({
+            type: "balancer",
+            state: "late_game",
+            tileable: false,
+            area: 43,
+          }),
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: "a84e9b6c-c920-4567-9ba0-2a018d734da7",
+          name: "16 - 8 Belt Balancer",
+          owner_id: "8358cfb0-2675-4651-a9c2-0d7cf57d6110",
+          blueprint:
+            "0eNqlmt1uo0AMhV8lmmuoZjx/hMu+xqpapS2qkFKCgKxaRbz7kr9ulQzFPnsVJRGfJx6fg8fkoJ63+6rt6mZQ5UHVL7umV+Wvg+rrt2azPX42fLaVKlU9VO8qU83m/fiu+mi7qu/zvt3Ww1B1asxU3bxWH6o0Y8a+fOg2Td/uuiF/rrbDNwiNT5mqmqEe6uq8oNObz9/N/v15CleaJVam2l0/Xb5rjqv4OF3xqco8TkFe6656OX/ljqu9YZOYTUl2SLDtfArvqPZMDQ9+mesEXHdZLYfrxbnIL3gGPMjhxIZHQUbyS6odJyWFfNWGveq1GK7ZbKPRwvbLojEGhQcG/F6S+8kourduN73+LPhbfPZlSU27P3rOfTQrF5PnVI5xsJosg45r1THoQaKny9ZaVlYQpRKLXKBqcmMKB4vTpnCkgaK+Wsntjn1V9W4/zJQ1mf+IZ4F48H2UUY5kcUeYzd2sI5ADotFC5uajeXmTwNIDBbmxsSRMEbYeYtALuE/g0Ncw3Szfuaz8nnu1uBs6pegGdSRKOZIluLVhJNpKbqu5fvDXNKRYkn7X/EMt75dHTYsY8ICbFs21MfMGbKNc7oYjd1ugcjcMOKxHBtxpFK6Xt9cZeSPDyrdD2t9LgOO6FyvFIXdTLeA71Fh0Sv3Oo7ikmbgA/3ojb4tcBEcXDPdyBcjmVPca7oG0+AjmNRzMiPstb8T9Fku2nsT+q1lci9ov4xTp4TMqowXwXu6QrAbUA6dTVsvsI+wNdmSUHjxM4mzlGj/wkdzYAjpessvmE9B5r11uogOBbEbHFyzsYyT2sSAfArM0EODBEuMgHwLe23iGwgIi4ItDAEOWAAvap1qTgI6ckrSokRNYchYW0XEvoyQiwaLx8lNSxCdJ8kFSdHAwLy/G6IFo9udo8z9NPlxiPW6JEZ2ghGThFrgfBGAL1qgfJFdfaBQXkzh0fsR40lmgt1UO24Luw2E7kB0YbA/LP4gFWcgfr1p2kuSjpcRj7Kfs/L+A8tu/EDK13UyLmz4zYZWvitXjtNLV42a7aV5O8D9V15+vLyJRYdY60jj+BcYaEMs=",
+          json: JSON.stringify(require("./bp1.json")),
+          metadata: JSON.stringify({
+            type: "balancer",
+            state: "late_game",
+            tileable: true,
+            area: 265,
+          }),
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+      {}
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add commands to revert seed here.
+     *
+     * Example:
+     * await queryInterface.bulkDelete('People', null, {});
+     */
+    await queryInterface.bulkDelete("builds", null, {})
+  },
+}

--- a/db/seeders/bp1.json
+++ b/db/seeders/bp1.json
@@ -1,0 +1,812 @@
+{
+    "blueprint": {
+        "icons": [{
+                "signal": {
+                    "type": "item",
+                    "name": "express-splitter"
+                },
+                "index": 1
+            },
+            {
+                "signal": {
+                    "type": "item",
+                    "name": "express-transport-belt"
+                },
+                "index": 2
+            }
+        ],
+        "entities": [{
+                "entity_number": 1,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": -7
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 2,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": -7
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 3,
+                "name": "express-splitter",
+                "position": {
+                    "x": 3,
+                    "y": -6.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 4,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": -7.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 5,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": -5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 6,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -2,
+                    "y": -5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 7,
+                "name": "express-splitter",
+                "position": {
+                    "x": -3,
+                    "y": -4.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 8,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": -5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 9,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": -5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 10,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": -5
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 11,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": -6
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 12,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": -6
+                },
+                "direction": 4,
+                "type": "input"
+            },
+            {
+                "entity_number": 13,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": -5.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 14,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": -3
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 15,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": -4
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 16,
+                "name": "express-splitter",
+                "position": {
+                    "x": -2,
+                    "y": -3.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 17,
+                "name": "express-splitter",
+                "position": {
+                    "x": -3,
+                    "y": -2.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 18,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": -4
+                }
+            },
+            {
+                "entity_number": 19,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": -3
+                }
+            },
+            {
+                "entity_number": 20,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -1,
+                    "y": -4
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 21,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -1,
+                    "y": -3
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 22,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": -4
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 23,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": -4
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 24,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 2,
+                    "y": -3
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 25,
+                "name": "express-splitter",
+                "position": {
+                    "x": 3,
+                    "y": -2.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 26,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": -3.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 27,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": -2
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 28,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -2,
+                    "y": -2
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 29,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -2,
+                    "y": -1
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 30,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -3,
+                    "y": -1
+                },
+                "direction": 2
+            },
+            {
+                "entity_number": 31,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": -2
+                }
+            },
+            {
+                "entity_number": 32,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": -2
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 33,
+                "name": "express-splitter",
+                "position": {
+                    "x": -0.5,
+                    "y": -1
+                }
+            },
+            {
+                "entity_number": 34,
+                "name": "express-splitter",
+                "position": {
+                    "x": 1.5,
+                    "y": -1
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 35,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": -2
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 36,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": -2
+                },
+                "direction": 4,
+                "type": "output"
+            },
+            {
+                "entity_number": 37,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": -1.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 38,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": 1
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 39,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -2,
+                    "y": 1
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 40,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -2,
+                    "y": 0
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 41,
+                "name": "express-splitter",
+                "position": {
+                    "x": -3,
+                    "y": 1.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 42,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -3,
+                    "y": 0
+                },
+                "type": "output"
+            },
+            {
+                "entity_number": 43,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 0,
+                    "y": 0
+                },
+                "type": "output"
+            },
+            {
+                "entity_number": 44,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 0
+                }
+            },
+            {
+                "entity_number": 45,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 1
+                }
+            },
+            {
+                "entity_number": 46,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 0,
+                    "y": 1
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 47,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": 1
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 48,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": 0
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 49,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 2,
+                    "y": 0
+                },
+                "direction": 4,
+                "type": "input"
+            },
+            {
+                "entity_number": 50,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 2,
+                    "y": 1
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 51,
+                "name": "express-splitter",
+                "position": {
+                    "x": 3,
+                    "y": 1.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 52,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": 0.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 53,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": 3
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 54,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": 2
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 55,
+                "name": "express-splitter",
+                "position": {
+                    "x": -3,
+                    "y": 3.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 56,
+                "name": "express-splitter",
+                "position": {
+                    "x": -2,
+                    "y": 2.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 57,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 0,
+                    "y": 3
+                },
+                "type": "input"
+            },
+            {
+                "entity_number": 58,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 3
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 59,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -1,
+                    "y": 2
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 60,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": 3
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 61,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": 3
+                },
+                "direction": 2
+            },
+            {
+                "entity_number": 62,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": 2
+                },
+                "direction": 4
+            },
+            {
+                "entity_number": 63,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 2,
+                    "y": 2
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 64,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": 2.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 65,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -4,
+                    "y": 4
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 66,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -3,
+                    "y": 5
+                },
+                "type": "input"
+            },
+            {
+                "entity_number": 67,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -2,
+                    "y": 4
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 68,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 5
+                }
+            },
+            {
+                "entity_number": 69,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": 5
+                }
+            },
+            {
+                "entity_number": 70,
+                "name": "express-splitter",
+                "position": {
+                    "x": -0.5,
+                    "y": 4
+                }
+            },
+            {
+                "entity_number": 71,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": 4
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 72,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 2,
+                    "y": 5
+                },
+                "direction": 4,
+                "type": "output"
+            },
+            {
+                "entity_number": 73,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": 4
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 74,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": 5
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 75,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 3,
+                    "y": 5
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 76,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": 4.5
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 77,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -3,
+                    "y": 6
+                }
+            },
+            {
+                "entity_number": 78,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": -2,
+                    "y": 6
+                },
+                "direction": 6,
+                "type": "output"
+            },
+            {
+                "entity_number": 79,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 6
+                }
+            },
+            {
+                "entity_number": 80,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": -1,
+                    "y": 7
+                }
+            },
+            {
+                "entity_number": 81,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 0,
+                    "y": 7
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 82,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 1,
+                    "y": 7
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 83,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": 7
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 84,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 2,
+                    "y": 6
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 85,
+                "name": "express-underground-belt",
+                "position": {
+                    "x": 1,
+                    "y": 6
+                },
+                "direction": 6,
+                "type": "input"
+            },
+            {
+                "entity_number": 86,
+                "name": "express-transport-belt",
+                "position": {
+                    "x": 3,
+                    "y": 7
+                },
+                "direction": 6
+            },
+            {
+                "entity_number": 87,
+                "name": "express-splitter",
+                "position": {
+                    "x": 4,
+                    "y": 6.5
+                },
+                "direction": 6
+            }
+        ],
+        "item": "blueprint",
+        "label": "16 - 8 Belt Balancer",
+        "version": 68722819072
+    }
+}

--- a/db/seeders/bp2.json
+++ b/db/seeders/bp2.json
@@ -1,0 +1,229 @@
+{
+    "blueprint_book": {
+        "blueprints": [{
+                "blueprint": {
+                    "icons": [{
+                            "signal": {
+                                "type": "item",
+                                "name": "express-transport-belt"
+                            },
+                            "index": 1
+                        },
+                        {
+                            "signal": {
+                                "type": "item",
+                                "name": "express-splitter"
+                            },
+                            "index": 2
+                        }
+                    ],
+                    "entities": [{
+                            "entity_number": 1,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": -1,
+                                "y": -2
+                            },
+                            "direction": 2
+                        },
+                        {
+                            "entity_number": 2,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 0,
+                                "y": -2
+                            }
+                        },
+                        {
+                            "entity_number": 3,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": -1,
+                                "y": 0
+                            },
+                            "type": "output"
+                        },
+                        {
+                            "entity_number": 4,
+                            "name": "express-splitter",
+                            "position": {
+                                "x": -0.5,
+                                "y": -1
+                            }
+                        },
+                        {
+                            "entity_number": 5,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "type": "output"
+                        },
+                        {
+                            "entity_number": 6,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 1,
+                                "y": 0
+                            },
+                            "direction": 6
+                        },
+                        {
+                            "entity_number": 7,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": -1,
+                                "y": 1
+                            },
+                            "type": "input"
+                        },
+                        {
+                            "entity_number": 8,
+                            "name": "express-splitter",
+                            "position": {
+                                "x": 0.5,
+                                "y": 2
+                            }
+                        },
+                        {
+                            "entity_number": 9,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 0,
+                                "y": 1
+                            },
+                            "direction": 6
+                        },
+                        {
+                            "entity_number": 10,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 1,
+                                "y": 1
+                            }
+                        }
+                    ],
+                    "item": "blueprint",
+                    "label": "1 Lane Balancer-Left",
+                    "version": 73019621376
+                },
+                "index": 0
+            },
+            {
+                "blueprint": {
+                    "icons": [{
+                            "signal": {
+                                "type": "item",
+                                "name": "express-transport-belt"
+                            },
+                            "index": 1
+                        },
+                        {
+                            "signal": {
+                                "type": "item",
+                                "name": "express-splitter"
+                            },
+                            "index": 2
+                        }
+                    ],
+                    "entities": [{
+                            "entity_number": 1,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 1,
+                                "y": -2
+                            },
+                            "direction": 6
+                        },
+                        {
+                            "entity_number": 2,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 0,
+                                "y": -2
+                            }
+                        },
+                        {
+                            "entity_number": 3,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": -1,
+                                "y": 0
+                            },
+                            "direction": 2
+                        },
+                        {
+                            "entity_number": 4,
+                            "name": "express-splitter",
+                            "position": {
+                                "x": 0.5,
+                                "y": -1
+                            }
+                        },
+                        {
+                            "entity_number": 5,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "type": "output"
+                        },
+                        {
+                            "entity_number": 6,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": 1,
+                                "y": 0
+                            },
+                            "type": "output"
+                        },
+                        {
+                            "entity_number": 7,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": -1,
+                                "y": 1
+                            }
+                        },
+                        {
+                            "entity_number": 8,
+                            "name": "express-splitter",
+                            "position": {
+                                "x": -0.5,
+                                "y": 2
+                            }
+                        },
+                        {
+                            "entity_number": 9,
+                            "name": "express-underground-belt",
+                            "position": {
+                                "x": 1,
+                                "y": 1
+                            },
+                            "type": "input"
+                        },
+                        {
+                            "entity_number": 10,
+                            "name": "express-transport-belt",
+                            "position": {
+                                "x": 0,
+                                "y": 1
+                            },
+                            "direction": 2
+                        }
+                    ],
+                    "item": "blueprint",
+                    "label": "1 Lane Balancer-Right",
+                    "version": 73019621376
+                },
+                "index": 1
+            }
+        ],
+        "item": "blueprint-book",
+        "label": "1 lane balancers",
+        "active_index": 0,
+        "version": 73019621376
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,15 +10,19 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@types/validator": "^13.1.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "next": "latest",
+    "pg": "^8.3.3",
+    "pg-hstore": "^2.3.3",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.2.1",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "styled-components": "^5.2.0",
+    "sequelize": "^6.3.5",
     "uuid": "^8.3.0",
     "yup": "^0.29.3"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@types/validator": "^13.1.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "next": "latest",
@@ -34,6 +33,7 @@
     "@types/react-redux": "^7.1.9",
     "@types/styled-components": "^5.1.3",
     "@types/uuid": "^8.3.0",
+    "@types/validator": "^13.1.0",
     "@types/yup": "^0.29.7",
     "babel-plugin-styled-components": "^1.11.1",
     "prettier": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/node@*":
+  version "14.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
+  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
+
 "@types/node@^12.12.21":
   version "12.12.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.62.tgz#733923d73669188d35950253dd18a21570085d2b"
@@ -1098,9 +1103,9 @@
     "@types/react" "*"
 
 "@types/react-native@*":
-  version "0.63.19"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.19.tgz#5302f3fecd47ea83626b0bafacbb0d9f2892a242"
-  integrity sha512-iUcejWDCw5gBIezDtSWBpkbB3piIMZau7FAfQqhObCJpCm/7QgVof/aKIP0fCkADYz/qGmIZATMX8kjAS7TVbw==
+  version "0.63.20"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.20.tgz#15ccf000bf849d867b15d14d2b4acc364fb7fa27"
+  integrity sha512-APnxRTDxbWw/IYjvwvXkhYJiz1gahyVA579pJqAVsEfZ+ZUwUHZpWKnexobyH5NmRJHuA/8LrThyps/BW3SYXA==
   dependencies:
     "@types/react" "*"
 
@@ -1136,6 +1141,11 @@
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
+"@types/validator@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.0.tgz#3d776127dbce7dd31fc06f86d3428b072e631eba"
+  integrity sha512-gHUHI6pJaANIO2r6WcbT7+WMgbL9GZooR4tWpuBOETpDIqFNxwaJluE+6rj6VGYe8k6OkfhbHz2Fkm8kl06Igw==
 
 "@types/yup@^0.29.7":
   version "0.29.7"
@@ -1387,6 +1397,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -1696,6 +1711,11 @@ buffer-from@^1.0.0, buffer-from@^1.1.1:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -1799,9 +1819,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001131:
-  version "1.0.30001133"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz#ec564c5495311299eb05245e252d589a84acd95e"
-  integrity sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw==
+  version "1.0.30001135"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
+  integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
 
 chalk@4.0.0:
   version "4.0.0"
@@ -2188,7 +2208,7 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
-debug@4, debug@^4.1.0:
+debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
@@ -2318,6 +2338,11 @@ domutils@^2.0.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
+
+dottie@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dottie/-/dottie-2.0.2.tgz#cc91c0726ce3a054ebf11c55fbc92a7f266dd154"
+  integrity sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -2836,10 +2861,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -2917,6 +2942,11 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
+inflection@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
+  integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2981,9 +3011,9 @@ is-buffer@^1.1.5:
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
-  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
+  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -3456,6 +3486,18 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
+moment-timezone@^0.5.31:
+  version "0.5.31"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
+  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.26.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.0.tgz#fcbef955844d91deb55438613ddcec56e86a3425"
+  integrity sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -3593,11 +3635,11 @@ node-fetch@2.6.0:
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-html-parser@^1.2.19:
-  version "1.2.20"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.2.20.tgz#37e9ebc627dbe3ff446eea4ac93e3d254b7c6ee4"
-  integrity sha512-1fUpYjAducDrrBSE0etRUV1tM+wSFTudmrslMXuk35wL/L29E7e1CLQn4CNzFLnqtYpmDlWhkD6VUloyHA0dwA==
+  version "1.2.21"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.2.21.tgz#93b074d877007c7148d594968a642cd65d254daa"
+  integrity sha512-6vDhgen6J332syN5HUmeT4FfBG7m6bFRrPN+FXY8Am7FGuVpsIxTASVbeoO5PF2IHbX2s+WEIudb1hgxOjllNQ==
   dependencies:
-    he "1.1.1"
+    he "1.2.0"
 
 node-libs-browser@^2.2.1:
   version "2.2.1"
@@ -3748,6 +3790,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -3823,6 +3870,65 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pg-connection-string@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.3.0.tgz#c13fcb84c298d0bfa9ba12b40dd6c23d946f55d6"
+  integrity sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==
+
+pg-hstore@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/pg-hstore/-/pg-hstore-2.3.3.tgz#d1978c12a85359830b1388d3b0ff233b88928e96"
+  integrity sha512-qpeTpdkguFgfdoidtfeTho1Q1zPVPbtMHgs8eQ+Aan05iLmIs3Z3oo5DOZRclPGoQ4i68I1kCtQSJSa7i0ZVYg==
+  dependencies:
+    underscore "^1.7.0"
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.2.1.tgz#5f4afc0f58063659aeefa952d36af49fa28b30e0"
+  integrity sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
+
+pg-protocol@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.2.5.tgz#28a1492cde11646ff2d2d06bdee42a3ba05f126c"
+  integrity sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.3.3:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.3.3.tgz#0338631ca3c39b4fb425b699d494cab17f5bb7eb"
+  integrity sha512-wmUyoQM/Xzmo62wgOdQAn5tl7u+IA1ZYK7qbuppi+3E+Gj4hlUxVHjInulieWrd0SfHi/ADriTb5ILJ/lsJrSg==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.3.0"
+    pg-pool "^3.2.1"
+    pg-protocol "^1.2.5"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  integrity sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
+  dependencies:
+    split "^1.0.0"
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
@@ -3906,13 +4012,14 @@ postcss-safe-parser@4.0.2:
     postcss "^7.0.26"
 
 postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
-  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.3.tgz#766d77728728817cc140fa1ac6da5e77f9fada98"
+  integrity sha512-0ClFaY4X1ra21LRqbW6y3rUbWcxnSVkDFG57R7Nxus9J9myPFlv+jYDMohzpkBx0RrjjiqjtycpchQ+PLGmZ9w==
   dependencies:
     cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+    util-deprecate "^1.0.2"
 
 postcss-value-parser@^4.0.2, postcss-value-parser@^4.0.3, postcss-value-parser@^4.1.0:
   version "4.1.0"
@@ -3945,6 +4052,28 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prettier@^2.1.2:
   version "2.1.2"
@@ -4267,6 +4396,13 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry-as-promised@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-3.2.0.tgz#769f63d536bec4783549db0777cb56dadd9d8543"
+  integrity sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==
+  dependencies:
+    any-promise "^1.3.0"
+
 rework-visit@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a"
@@ -4377,6 +4513,11 @@ schema-utils@^2.6.1, schema-utils@^2.6.6:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
+  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
+
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -4391,6 +4532,35 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+sequelize-pool@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-6.1.0.tgz#caaa0c1e324d3c2c3a399fed2c7998970925d668"
+  integrity sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
+
+sequelize@^6.3.5:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.3.5.tgz#80e3db7ac8b76d98c45ca93334197eb6e2335158"
+  integrity sha512-MiwiPkYSA8NWttRKAXdU9h0TxP6HAc1fl7qZmMO/VQqQOND83G4nZLXd0kWILtAoT9cxtZgFqeb/MPYgEeXwsw==
+  dependencies:
+    debug "^4.1.1"
+    dottie "^2.0.0"
+    inflection "1.12.0"
+    lodash "^4.17.15"
+    moment "^2.26.0"
+    moment-timezone "^0.5.31"
+    retry-as-promised "^3.2.0"
+    semver "^7.3.2"
+    sequelize-pool "^6.0.0"
+    toposort-class "^1.0.1"
+    uuid "^8.1.0"
+    validator "^10.11.0"
+    wkx "^0.5.0"
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -4526,6 +4696,13 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+split@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
 
 ssri@^6.0.1:
   version "6.0.1"
@@ -4755,6 +4932,11 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
@@ -4808,6 +4990,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toposort-class@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
+  integrity sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=
 
 toposort@^2.0.2:
   version "2.0.2"
@@ -4865,6 +5052,11 @@ typescript@4.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
+underscore@^1.7.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz#dd7c23a195db34267186044649870ff1bab5929e"
+  integrity sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -4963,7 +5155,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -4982,10 +5174,15 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^8.3.0:
+uuid@^8.1.0, uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+
+validator@^10.11.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
+  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
 vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"
@@ -5073,6 +5270,13 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+wkx@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.5.0.tgz#c6c37019acf40e517cc6b94657a25a3d4aa33e8c"
+  integrity sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==
+  dependencies:
+    "@types/node" "*"
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
- This commit adds the initial data model and the dependencies for Sequelize as the ORM for factorio-builds.
- Currently there is no integration into the next.js app, only the model definitions
- No change has been made to existing models, as such this is completely unrelated to current resources

To bootstrap the datasource, make sure you have the sequelize command line installed with `yarn global add sequelize-cli`. Then you'll need to use the `db/config/config.example.js` and create `db/config/config.js` with your database credentials.

To create the data models run `sequelize db:migrate` and to populate use `sequelize db:seed:all`