### PR TITLE
Remove API Fetch calls from model pages

### DIFF
--- a/components/BuildPage/build-page.component.tsx
+++ b/components/BuildPage/build-page.component.tsx
@@ -84,7 +84,9 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
                 <br />({formatSince(build.updatedAt)})
               </SC.AsideSubGroup>
             </AsideGroup>
-            <AsideGroup title="Categories">{build.metadata.type}</AsideGroup>
+            <AsideGroup title="Categories">
+              {build.metadata.categories}
+            </AsideGroup>
             <AsideGroup title="Game state">{build.metadata.state}</AsideGroup>
             <AsideGroup title="Required items">
               {!isBook(blueprintJSON) ? (
@@ -108,6 +110,7 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
 
             <SC.MainContent>
               <p>ID: {build.id}</p>
+              // TODO kenperkins: should this be build.description?
               <p>
                 Lorem ipsum dolor sit amet consectetur adipisicing elit.
                 Distinctio, cum beatae voluptate deleniti error suscipit

--- a/components/BuildPage/build-page.component.tsx
+++ b/components/BuildPage/build-page.component.tsx
@@ -85,7 +85,9 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
               </SC.AsideSubGroup>
             </AsideGroup>
             <AsideGroup title="Categories">
-              {build.metadata.categories}
+              {build.metadata.categories.map((category) => (
+                <div>{category}</div>
+              ))}
             </AsideGroup>
             <AsideGroup title="Game state">{build.metadata.state}</AsideGroup>
             <AsideGroup title="Required items">

--- a/components/Header/header.component.tsx
+++ b/components/Header/header.component.tsx
@@ -8,7 +8,7 @@ function Header(): JSX.Element {
     <SC.HeaderWrapper>
       <Container>
         <Link href="/">my blueprints</Link>
-        <Link href="/builds/create">
+        <Link href="/build/create">
           <SC.CreateBuildButton>Add a build</SC.CreateBuildButton>
         </Link>
       </Container>

--- a/components/ListItemBuild.tsx
+++ b/components/ListItemBuild.tsx
@@ -8,7 +8,7 @@ interface IListItemBuildProps {
 }
 
 const ListItemBuild: React.FC<IListItemBuildProps> = ({ data }) => (
-  <Link href="/builds/[id]" as={`/builds/${data.id}`}>
+  <Link href="/build/[id]" as={`/build/${data.id}`}>
     <a>
       {data.id}: {data.name}
     </a>

--- a/db/models/build.js
+++ b/db/models/build.js
@@ -5,8 +5,6 @@ module.exports = (sequelize, DataTypes) => {
   class build extends Model {
     static associate(models) {
       this.belongsTo(models.user, {
-        foreignKey: "owner_id",
-        targetKey: "id",
         onDelete: "SET NULL",
         as: "owner",
       })
@@ -15,10 +13,6 @@ module.exports = (sequelize, DataTypes) => {
   build.init(
     {
       name: DataTypes.STRING,
-      ownerId: {
-        field: "owner_id",
-        type: DataTypes.UUID,
-      },
       blueprint: DataTypes.TEXT,
       json: DataTypes.JSONB,
       metadata: DataTypes.JSONB,

--- a/pages/api/build/index.ts
+++ b/pages/api/build/index.ts
@@ -26,6 +26,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         break
       case "POST": {
         const body = JSON.parse(req.body)
+
+        // @ts-ignore
+        const owner = await db.user
+          .findByPk("8358cfb0-2675-4651-a9c2-0d7cf57d6110")
+          // @ts-ignore
+          .catch((error) => {
+            console.error(error)
+            throw new Error("Cannot find user data")
+          })
+
         // @ts-ignore
         const build = await db.build.create({
           id: uuidv4(),
@@ -37,6 +47,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             type: body.categories.length ? body.categories : [],
             something: false,
           },
+          owner: owner,
         })
 
         res.status(200).json(build)

--- a/pages/build/[id].tsx
+++ b/pages/build/[id].tsx
@@ -62,8 +62,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
       id: build.id,
       name: build.name,
       blueprint: build.blueprint,
-      createdAt: build.createdAt.toString(),
-      updatedAt: build.updatedAt.toString(),
+      createdAt: build.createdAt.toISOString(),
+      updatedAt: build.updatedAt.toISOString(),
       metadata: metadata,
       owner: owner,
     }

--- a/pages/build/[id].tsx
+++ b/pages/build/[id].tsx
@@ -1,8 +1,9 @@
 import { GetServerSideProps } from "next"
-
-import { IBuild } from "../../types"
+import db from "../../db/models"
+import { ECategory, IBuild, EState, IUser, IMetadata } from "../../types"
 import Layout from "../../components/Layout"
 import BuildPage from "../../components/BuildPage"
+import { isEmptyChildren } from "formik"
 
 interface IBuildsPageProps {
   build?: IBuild
@@ -29,13 +30,51 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   try {
     const id = params?.id
 
-    const build: IBuild = await fetch(
-      "http://localhost:3000/api/build/" + id
-    ).then((res) => res.json())
+    // @ts-ignore
+    const build = await db.build
+      .findByPk(id, {
+        // @ts-ignore
+        include: [{ model: db.user, as: "owner" }],
+      })
+
+      // @ts-ignore
+      .catch((error) => {
+        console.error(error)
+        throw new Error("Cannot find build data")
+      })
 
     if (!build) throw new Error("Build not found")
 
-    return { props: { build } }
+    // Let's fix up the types so we're returning exactly what we've been asked for from a typescript standpoint
+    const metadata: IMetadata = {
+      tileable: build.metadata.tileable,
+      area: build.metadata.area,
+      state: EState.EARLY_GAME,
+      categories: [ECategory.BALANCER],
+    }
+
+    const owner: IUser = {
+      id: build.owner.id,
+      name: build.owner.name,
+    }
+
+    const buildInt: IBuild = {
+      id: build.id,
+      name: build.name,
+      blueprint: build.blueprint,
+      createdAt: build.createdAt.toString(),
+      updatedAt: build.updatedAt.toString(),
+      metadata: metadata,
+      owner: owner,
+    }
+
+    const response: IBuildsPageProps = {
+      build: buildInt,
+    }
+
+    return {
+      props: response,
+    }
   } catch (err) {
     return { props: { errors: err.message } }
   }

--- a/pages/build/[id].tsx
+++ b/pages/build/[id].tsx
@@ -45,35 +45,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
 
     if (!build) throw new Error("Build not found")
 
-    // Let's fix up the types so we're returning exactly what we've been asked for from a typescript standpoint
-    const metadata: IMetadata = {
-      tileable: build.metadata.tileable,
-      area: build.metadata.area,
-      state: EState.EARLY_GAME,
-      categories: [ECategory.BALANCER],
-    }
-
-    const owner: IUser = {
-      id: build.owner.id,
-      name: build.owner.name,
-    }
-
-    const buildInt: IBuild = {
-      id: build.id,
-      name: build.name,
-      blueprint: build.blueprint,
-      createdAt: build.createdAt.toISOString(),
-      updatedAt: build.updatedAt.toISOString(),
-      metadata: metadata,
-      owner: owner,
-    }
-
-    const response: IBuildsPageProps = {
-      build: buildInt,
-    }
-
     return {
-      props: response,
+      props: { build: JSON.parse(JSON.stringify(build)) },
     }
   } catch (err) {
     return { props: { errors: err.message } }

--- a/pages/build/[id].tsx
+++ b/pages/build/[id].tsx
@@ -1,9 +1,8 @@
 import { GetServerSideProps } from "next"
 import db from "../../db/models"
-import { ECategory, IBuild, EState, IUser, IMetadata } from "../../types"
+import { IBuild } from "../../types"
 import Layout from "../../components/Layout"
 import BuildPage from "../../components/BuildPage"
-import { isEmptyChildren } from "formik"
 
 interface IBuildsPageProps {
   build?: IBuild

--- a/pages/build/create.tsx
+++ b/pages/build/create.tsx
@@ -20,7 +20,7 @@ const BuildsCreatePage: React.FC = () => {
           categories: [],
         }}
         onSubmit={(values) => {
-          fetch("http://localhost:3000/api/build", {
+          fetch("/api/build", {
             method: "POST",
             body: JSON.stringify(values),
           }).then((res) => {

--- a/pages/build/index.tsx
+++ b/pages/build/index.tsx
@@ -5,6 +5,7 @@ import { IBuild } from "../../types"
 import Layout from "../../components/Layout"
 import ListBuild from "../../components/ListBuild"
 import { initializeStore } from "../../redux/store"
+import db from "../../db/models"
 
 interface IBuildsIndexPageProps {
   items: IBuild[]
@@ -13,7 +14,7 @@ interface IBuildsIndexPageProps {
 const BuildsIndexPage: React.FC<IBuildsIndexPageProps> = ({ items }) => (
   <Layout title="Builds List | Next.js + TypeScript Example">
     <h1>Builds List</h1>
-    <p>You are currently on: /builds</p>
+    <p>You are currently on: /build</p>
     <ListBuild items={items} />
     <p>
       <Link href="/">
@@ -27,16 +28,23 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const reduxStore = initializeStore()
   const { dispatch } = reduxStore
 
-  const builds: IBuild[] = await fetch(
-    "http://localhost:3000/api/build"
-  ).then((res) => res.json())
+  // @ts-ignore
+  const builds: IBuild[] = await db.build
+    .findAll({
+      attributes: ["id", "owner_id", "name", "metadata"],
+    })
+    // @ts-ignore
+    .catch((error) => {
+      console.error(error)
+      throw new Error("Cannot find build data")
+    })
 
   dispatch({
     type: "SET_BUILDS",
     payload: builds,
   })
 
-  return { props: { items: builds } }
+  return { props: { items: JSON.parse(JSON.stringify(builds)) } }
 }
 
 export default BuildsIndexPage

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import Filters from "../components/Filters"
 import SearchInput from "../components/SearchInput"
 import { initializeStore, IStoreState } from "../redux/store"
 import { IBuild } from "../types"
+import db from "../db/models"
 
 const IndexPage: React.FC = () => {
   const builds = useSelector((store: IStoreState) => store.builds.items)
@@ -27,13 +28,20 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const reduxStore = initializeStore()
   const { dispatch } = reduxStore
 
-  const builds: IBuild[] = await fetch(
-    "http://localhost:3000/api/build"
-  ).then((res) => res.json())
+  // @ts-ignore
+  const builds: IBuild[] = await db.build
+    .findAll({
+      attributes: ["id", "owner_id", "name", "metadata"],
+    })
+    // @ts-ignore
+    .catch((error) => {
+      console.error(error)
+      throw new Error("Cannot find build data")
+    })
 
   dispatch({
     type: "SET_BUILDS",
-    payload: builds,
+    payload: JSON.parse(JSON.stringify(builds)),
   })
 
   return { props: { initialReduxState: reduxStore.getState() } }

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,14 +16,18 @@ export enum ECategory {
   "PRODUCTION" = "PRODUCTION",
 }
 
+export interface IMetadata {
+  tileable: boolean
+  area: number
+  state: EState
+  categories: ECategory[]
+}
+
 export interface IBuild {
   id: string
   blueprint: string
-  metadata: any
+  metadata: IMetadata
   name: string
-  state: EState
-  tileable: boolean
-  categories: ECategory[]
   createdAt: string
   updatedAt: string
   owner: IUser


### PR DESCRIPTION
I'm attempting a few things in this WIP PR:

1) Cleaning up the Sequelize models; as I get a bit more familiar with the convention realizing there are some fields that we don't need to explicitly define
2) Removing calls to the api from the `getServerStaticProps` in lieu of directly connecting to the database
3) Cleaning up the `IBuild` interface with `IMetadata` and correct types for the keys in the map.

Currently however this doesn't work when viewing a build page. The index page works, but did require a hack with the JSON DateTime as documented in https://github.com/vercel/next.js/discussions/11209#discussioncomment-35915

The build page is totally broken, and I have no idea why:

```
SerializableError: Error serializing `.meta` returned from `getServerSideProps` in "/build/[id]".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.
    at isSerializable (/home/ken/src/factorio-builds/node_modules/next/dist/lib/is-serializable-props.js:7:95)
    at /home/ken/src/factorio-builds/node_modules/next/dist/lib/is-serializable-props.js:7:503
    at Array.every (<anonymous>)
    at isSerializable (/home/ken/src/factorio-builds/node_modules/next/dist/lib/is-serializable-props.js:7:304)
    at isSerializableProps (/home/ken/src/factorio-builds/node_modules/next/dist/lib/is-serializable-props.js:9:219)
    at renderToHTML (/home/ken/src/factorio-builds/node_modules/next/dist/next-server/server/render.js:38:395)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async /home/ken/src/factorio-builds/node_modules/next/dist/next-server/server/next-server.js:76:329
    at async /home/ken/src/factorio-builds/node_modules/next/dist/next-server/server/next-server.js:75:142
```