### PR TITLE
Adding a description field to create model

### DIFF
--- a/pages/api/build/index.ts
+++ b/pages/api/build/index.ts
@@ -41,14 +41,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           id: uuidv4(),
           name: body.name,
           blueprint: body.blueprint,
+          description: body.description,
           json: {},
           metadata: {
             state: body.state.toLowerCase(),
-            type: body.categories.length ? body.categories : [],
-            something: false,
+            categories: body.categories.length ? body.categories : [],
+            tileable: body.tileable,
           },
-          owner: owner,
         })
+
+        await build.setOwner(owner)
 
         res.status(200).json(build)
         break

--- a/pages/build/create.tsx
+++ b/pages/build/create.tsx
@@ -16,7 +16,9 @@ const BuildsCreatePage: React.FC = () => {
         initialValues={{
           name: "",
           blueprint: "",
+          description: "",
           state: undefined,
+          tileable: false,
           categories: [],
         }}
         onSubmit={(values) => {
@@ -44,12 +46,42 @@ const BuildsCreatePage: React.FC = () => {
 
             <div>
               <label
+                htmlFor="description"
+                style={{ display: "block", fontWeight: 700, marginTop: "8px" }}
+              >
+                Description
+              </label>
+              <Field
+                as="textarea"
+                id="description"
+                name="description"
+                rows="5"
+              />
+            </div>
+
+            <div>
+              <label
                 htmlFor="blueprint"
                 style={{ display: "block", fontWeight: 700, marginTop: "8px" }}
               >
                 Blueprint
               </label>
               <Field as="textarea" id="blueprint" name="blueprint" rows="5" />
+            </div>
+
+            <div>
+              <label
+                htmlFor="tileable"
+                style={{ display: "block", fontWeight: 700, marginTop: "8px" }}
+              >
+                Tileable
+              </label>
+              <Field
+                type="checkbox"
+                id="tileable"
+                name="tileable"
+                value="tileable"
+              />
             </div>
 
             <div>


### PR DESCRIPTION
I don't know why but the `tileable` checkbox is disabled. Otherwise this creates a record with markdown description.

p.s. the user is hard-coded for now.

![image](https://user-images.githubusercontent.com/730664/94480554-50a4ed80-018b-11eb-8093-45c618db50d1.png)
