### PR TITLE
Standardize env variable on APP_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DEBUG_REDUX=false
-APP_ENDPOINT="http://localhost:3000"
+APP_URL="http://localhost:3000"
 REDIS_HOST="127.0.0.1"
 TYPEORM_CONNECTION="postgres"
 TYPEORM_HOST="127.0.0.1"

--- a/pages-components/BuildFormPage/build-form-page.component.tsx
+++ b/pages-components/BuildFormPage/build-form-page.component.tsx
@@ -164,7 +164,7 @@ const BuildFormPage: React.FC<TBuildFormPage> = (props) => {
           error: false,
         })
         axios({
-          url: `${process.env.APP_ENDPOINT}/api/${endpoint}`,
+          url: `${process.env.APP_URL}/api/${endpoint}`,
           method: props.type === "EDIT" ? "PUT" : "POST",
           data: toFormData(values as IValidFormValues),
         })


### PR DESCRIPTION
We had inconsistent usage of `APP_URL` and `APP_ENDPOINT`. This change updates the code to use `APP_URL` exclusively and updates the example to match.

- Fixes #199