### PR TITLE
feat: increment build page

### DIFF
--- a/components/ui/Button/button.component.tsx
+++ b/components/ui/Button/button.component.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import * as SC from "./button.styles"
 
 interface IButtonProps extends React.ComponentPropsWithoutRef<"button"> {
-  variant?: "success" | "default"
+  variant?: "success" | "alt" | "default"
 }
 
 const Button: React.FC<IButtonProps> = ({

--- a/components/ui/Button/button.styles.tsx
+++ b/components/ui/Button/button.styles.tsx
@@ -5,11 +5,17 @@ import { ETypo } from "../../../design/tokens/typo"
 export const ButtonWrapper = styled.button`
   ${getTypo(ETypo.BUTTON)};
   display: flex;
+  align-items: center;
   padding: 9px 13px;
   color: #fff;
   border: none;
   border-radius: 5px;
   cursor: pointer;
+
+  img,
+  svg {
+    margin-right: 8px;
+  }
 
   &[disabled] {
     pointer-events: none;
@@ -27,5 +33,13 @@ export const ButtonWrapper = styled.button`
 
   &.variant-success:hover {
     background: linear-gradient(#47b34c, #2b592d);
+  }
+
+  &.variant-alt {
+    background: linear-gradient(#2ca0ba, #246b7a);
+  }
+
+  &.variant-alt:hover {
+    background: linear-gradient(#25879d, #1f5d6a);
   }
 `

--- a/icons/copy.tsx
+++ b/icons/copy.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+const Copy: React.FC = (props) => {
+  return (
+    <svg
+      {...props}
+      width="14"
+      height="14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.864 0H2.227C1.527 0 .955.573.955 1.273v8.909h1.272v-8.91h7.637V0zm1.909 2.545h-7c-.7 0-1.273.573-1.273 1.273v8.91c0 .7.573 1.272 1.273 1.272h7c.7 0 1.273-.573 1.273-1.273V3.818c0-.7-.573-1.273-1.273-1.273zm0 10.182h-7V3.818h7v8.91z"
+        fill="#fff"
+      />
+    </svg>
+  )
+}
+
+export default Copy

--- a/pages-components/BuildPage/build-page.component.tsx
+++ b/pages-components/BuildPage/build-page.component.tsx
@@ -150,6 +150,14 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
                 {state.name}
               </MetadataWithIcon>
             </AsideGroup>
+            <AsideGroup title="Extra">
+              <SC.AsideSubGroup>
+                Inputs are marked: {build.metadata.markedInputs ? "yes" : "no"}
+              </SC.AsideSubGroup>
+              <SC.AsideSubGroup>
+                Tileable: {build.metadata.tileable ? "yes" : "no"}
+              </SC.AsideSubGroup>
+            </AsideGroup>
             {!isBook(build.json) && (
               <AsideGroup title="Required items">
                 {sortedRequiredItems.map((item) => {

--- a/pages-components/BuildPage/build-page.component.tsx
+++ b/pages-components/BuildPage/build-page.component.tsx
@@ -6,6 +6,7 @@ import { format, formatDistanceToNow, parseISO } from "date-fns"
 import Link from "next/link"
 import BuildSubheader from "../../components/ui/BuildSubheader"
 import Layout from "../../components/ui/Layout"
+import Stacker from "../../components/ui/Stacker"
 import { Build } from "../../db/entities/build.entity"
 import { useCategories } from "../../hooks/useCategories"
 import { useGameStates } from "../../hooks/useGameStates"
@@ -181,52 +182,54 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
             )}
           </SC.Aside>
           <SC.Main>
-            <SC.MainTitle>Description</SC.MainTitle>
+            <Stacker gutter={8}>
+              <SC.MainTitle>Description</SC.MainTitle>
 
-            <SC.MainContent>
-              {build.description ? (
-                <ReactMarkdown source={build.description} />
-              ) : (
-                <em>No description provided</em>
+              <SC.MainContent>
+                {build.description ? (
+                  <ReactMarkdown source={build.description} />
+                ) : (
+                  <em>No description provided</em>
+                )}
+              </SC.MainContent>
+
+              <SC.ExpandBlueprint onClick={toggleExpandBlueprint}>
+                expand blueprint <Caret inverted={blueprintExpanded} />
+              </SC.ExpandBlueprint>
+
+              {blueprintExpanded && (
+                <SC.Blueprint>
+                  <SC.TogglerWrapper>
+                    <SC.Toggler
+                      className={cx({
+                        "is-selected": blueprintFormat === "base64",
+                      })}
+                      onClick={() => setBlueprintFormat("base64")}
+                    >
+                      base64
+                    </SC.Toggler>
+                    <SC.Toggler
+                      className={cx({
+                        "is-selected": blueprintFormat === "json",
+                      })}
+                      onClick={() => setBlueprintFormat("json")}
+                    >
+                      json
+                    </SC.Toggler>
+                  </SC.TogglerWrapper>
+                  <SC.BlueprintData
+                    value={
+                      blueprintFormat === "json"
+                        ? JSON.stringify(build.json, null, 1)
+                        : build.blueprint
+                    }
+                    rows={5}
+                    readOnly
+                    onClick={(e) => e.currentTarget.select()}
+                  />
+                </SC.Blueprint>
               )}
-            </SC.MainContent>
-
-            <SC.ExpandBlueprint onClick={toggleExpandBlueprint}>
-              expand blueprint <Caret inverted={blueprintExpanded} />
-            </SC.ExpandBlueprint>
-
-            {blueprintExpanded && (
-              <SC.Blueprint>
-                <SC.TogglerWrapper>
-                  <SC.Toggler
-                    className={cx({
-                      "is-selected": blueprintFormat === "base64",
-                    })}
-                    onClick={() => setBlueprintFormat("base64")}
-                  >
-                    base64
-                  </SC.Toggler>
-                  <SC.Toggler
-                    className={cx({
-                      "is-selected": blueprintFormat === "json",
-                    })}
-                    onClick={() => setBlueprintFormat("json")}
-                  >
-                    json
-                  </SC.Toggler>
-                </SC.TogglerWrapper>
-                <SC.BlueprintData
-                  value={
-                    blueprintFormat === "json"
-                      ? JSON.stringify(build.json, null, 1)
-                      : build.blueprint
-                  }
-                  rows={5}
-                  readOnly
-                  onClick={(e) => e.currentTarget.select()}
-                />
-              </SC.Blueprint>
-            )}
+            </Stacker>
           </SC.Main>
         </SC.Content>
       </SC.Wrapper>

--- a/pages-components/BuildPage/build-page.component.tsx
+++ b/pages-components/BuildPage/build-page.component.tsx
@@ -1,16 +1,18 @@
-import React, { useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import { useSelector } from "react-redux"
 import cx from "classnames"
 import { format, formatDistanceToNow, parseISO } from "date-fns"
 import Link from "next/link"
 import BuildSubheader from "../../components/ui/BuildSubheader"
+import Button from "../../components/ui/Button"
 import Layout from "../../components/ui/Layout"
 import Stacker from "../../components/ui/Stacker"
 import { Build } from "../../db/entities/build.entity"
 import { useCategories } from "../../hooks/useCategories"
 import { useGameStates } from "../../hooks/useGameStates"
 import Caret from "../../icons/caret"
+import Copy from "../../icons/copy"
 import { IStoreState } from "../../redux/store"
 import { ERole } from "../../types"
 import { getCountPerItem, isBook } from "../../utils/blueprint"
@@ -95,6 +97,10 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
       })
   }, [itemsCount])
 
+  const copyToClipboard = useCallback(() => {
+    navigator.clipboard.writeText(build.blueprint)
+  }, [build.blueprint])
+
   const isAdmin = user?.roleName === ERole.ADMIN
   const ownedByMe = build.owner.id === user?.id
   const state = getGameState(build.metadata.state)
@@ -112,6 +118,11 @@ function BuildPage({ build }: IBuildPageProps): JSX.Element {
       <SC.Wrapper>
         <SC.Content>
           <SC.Aside>
+            <SC.CopyClipboardWrapper>
+              <Button variant="alt" onClick={copyToClipboard}>
+                <Copy /> copy to clipboard
+              </Button>
+            </SC.CopyClipboardWrapper>
             {(isAdmin || ownedByMe) && (
               <AsideGroup>
                 <Link href={`/build/${build.id}/edit`}>

--- a/pages-components/BuildPage/build-page.styles.tsx
+++ b/pages-components/BuildPage/build-page.styles.tsx
@@ -27,6 +27,10 @@ export const Aside = styled.aside`
   flex: 0 0 250px;
 `
 
+export const CopyClipboardWrapper = styled.div`
+  margin-bottom: 16px;
+`
+
 export const AsideGroup = styled.section`
   & + & {
     margin-top: 8px;

--- a/pages-components/BuildPage/build-page.styles.tsx
+++ b/pages-components/BuildPage/build-page.styles.tsx
@@ -78,7 +78,7 @@ export const Main = styled.main`
 
 export const MainTitle = styled.h3`
   ${getTypo(ETypo.PAGE_SUBTITLE)};
-  margin-top: 0;
+  margin: 0;
 `
 
 export const MainContent = styled.div`
@@ -100,6 +100,7 @@ export const ExpandBlueprint = styled.button`
   border: none;
   color: ${COLOR.LINK};
   padding: 0;
+  align-self: flex-start;
 `
 
 export const Blueprint = styled.div`

--- a/pages-components/BuildPage/build-page.styles.tsx
+++ b/pages-components/BuildPage/build-page.styles.tsx
@@ -95,6 +95,7 @@ export const MainContent = styled.div`
 
 export const ExpandBlueprint = styled.button`
   ${getTypo(ETypo.BUTTON)};
+  cursor: pointer;
   background: none;
   border: none;
   color: ${COLOR.LINK};


### PR DESCRIPTION
- Adds tileable and marked inputs to blueprint page
- Tweak build body formatting
- Make the cursor a pointer on highlighting "expand blueprint"
- Adds a copy (blueprint string) to clipboard button

![image](https://user-images.githubusercontent.com/3461986/100573291-7773c300-32a5-11eb-8144-880a567543bb.png)
