### PR TITLE
Add isBook to IMetadata interface

### DIFF
--- a/components/ui/BuildCardList/build-card-list.component.tsx
+++ b/components/ui/BuildCardList/build-card-list.component.tsx
@@ -31,7 +31,7 @@ const BuildCardList: React.FC<IBuildCardListProps> = ({ items }) => {
                 name={item.name}
                 categories={item.metadata.categories}
                 // @ts-ignore
-                isBook={item.isBook}
+                isBook={item.metadata.isBook}
                 image={item.image}
                 id={item.id}
               />

--- a/db/seeds/data/builds.ts
+++ b/db/seeds/data/builds.ts
@@ -16,6 +16,7 @@ export const builds: Omit<Build, "owner">[] = [
       tileable: false,
       markedInputs: false,
       area: 43,
+      isBook: true
     },
     image: {
       src:
@@ -41,6 +42,7 @@ export const builds: Omit<Build, "owner">[] = [
       tileable: true,
       markedInputs: false,
       area: 265,
+      isBook: false
     },
     image: {
       src:
@@ -67,6 +69,7 @@ export const builds: Omit<Build, "owner">[] = [
       tileable: true,
       markedInputs: false,
       area: 265,
+      isBook: false
     },
     image: {
       src:

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import { Build } from "../db/entities/build.entity"
 import { BuildRepository } from "../db/repository/build.repository"
 import BuildListPage from "../pages-components/BuildListPage"
 import { wrapper } from "../redux/store"
-import { decodeBlueprint, isBook } from "../utils/blueprint"
 
 const IndexPage: NextPage = () => {
   return <BuildListPage />
@@ -22,18 +21,9 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
 
     const deserializedBuilds: Build[] = JSON.parse(JSON.stringify(builds))
 
-    // temp until part of data structure/metadata
-    const tempBuilds = deserializedBuilds.map((build) => {
-      const decodedBlueprint = decodeBlueprint(build.blueprint)
-      return {
-        ...build,
-        isBook: isBook(decodedBlueprint),
-      }
-    })
-
     ctx.store.dispatch({
       type: "SET_BUILDS",
-      payload: tempBuilds,
+      payload: deserializedBuilds,
     })
 
     return { props: {} }

--- a/server/usecase/build.usecase.ts
+++ b/server/usecase/build.usecase.ts
@@ -9,7 +9,7 @@ import { User } from "../../db/entities/user.entity"
 import { BuildRepository } from "../../db/repository/build.repository"
 import { UserRepository } from "../../db/repository/user.repository"
 import { EState } from "../../types"
-import { decodeBlueprint } from "../../utils/blueprint"
+import { decodeBlueprint, isBook } from "../../utils/blueprint"
 import {
   EntityNotFoundException,
   EntityPermissonException,
@@ -106,12 +106,15 @@ async function buildMapper({
   owner?: User
 }): Promise<Build> {
   // @ts-ignore
+  const book = decodeBlueprint(fields.blueprint as string)
+
+  // @ts-ignore
   const build: Build = {
     id: buildId,
     name: fields.name as string,
     blueprint: fields.blueprint as string,
     description: fields.description as string,
-    json: decodeBlueprint(fields.blueprint as string),
+    json: book,
     metadata: {
       state: fields.state as EState,
       // @ts-ignore
@@ -121,6 +124,7 @@ async function buildMapper({
       markedInputs: Boolean(fields.markedInputs as string),
       tileable: Boolean(fields.tileable as string),
       area: 0,
+      isBook: isBook(book)
     },
   }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -31,6 +31,7 @@ export interface IMetadata {
   state: EState
   categories: ECategory[]
   markedInputs: boolean
+  isBook: boolean
 }
 
 export interface IImage {


### PR DESCRIPTION
This changes adds `isBook` as a boolean on IMetadata interface. This is easier to do at creation time so we don't need to decode the blueprint for the index page, which will be done in a following contribution.

- Fixes #201