### PR TITLE
Adding a lighter weight index page query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps, NextPage } from "next"
-import { IsNull, Not } from "typeorm"
 import { Build } from "../db/entities/build.entity"
 import { BuildRepository } from "../db/repository/build.repository"
 import BuildListPage from "../pages-components/BuildListPage"
@@ -16,7 +15,6 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
       "build.id",
       "build.name",
       "build.metadata",
-      "build.blueprint",
       "build.image"
     ])
       .where("build.image IS NOT NULL")

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,8 +12,15 @@ const IndexPage: NextPage = () => {
 export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(
   async (ctx) => {
     const buildRepository = await BuildRepository()
-    const builds = await buildRepository
-      .find({ image: Not(IsNull()) })
+    const builds = await buildRepository.createQueryBuilder("build").select([
+      "build.id",
+      "build.name",
+      "build.metadata",
+      "build.blueprint",
+      "build.image"
+    ])
+      .where("build.image IS NOT NULL")
+      .getMany()
       .catch((error) => {
         console.error(error)
         throw new Error("Cannot find build data")


### PR DESCRIPTION
The removes the blueprint from the query, which is not needed on the index page.

Fixes #185 