### PR TITLE
chore: bump actions/cache to v3

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v1.3.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -26,7 +26,7 @@ jobs:
           working-directory: ./frontend
 
       - name: Restore next build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-build-cache
         env:
           cache-name: cache-next-build


### PR DESCRIPTION
## Summary
- Bump `actions/cache` from v2.1.5 / v2 to v3 in both workflows to fix CI failures caused by GitHub's deprecation of v1/v2.

## Test plan
- [ ] CI runs successfully on this PR