### PR TITLE
ci: use GITHUB_TOKEN for ghcr.io login

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,6 +19,9 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -43,8 +46,8 @@ jobs:
         uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure tags are in sync
         run: diff frontend/tags.json backend/tags.json


### PR DESCRIPTION
## Summary
- CI was failing at `docker/login-action` with `denied: denied` because the `CONTAINER_REGISTRY_TOKEN` PAT is no longer accepted by ghcr.io.
- Switch the login to the auto-issued `GITHUB_TOKEN` and grant the job `packages: write` so it can push images.

## Note
First push under the new token may publish packages as private. If anonymous pulls are expected, set each ghcr package's visibility to public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)