### PR TITLE
ci: add frontend dependency stats workflow

### DIFF
--- a/.github/scripts/collect-frontend-stats.sh
+++ b/.github/scripts/collect-frontend-stats.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -e
+
+# Collect dependency stats for the frontend package.
+# Outputs a single JSON file at .github/stats/frontend.json
+#
+# Run from the repo root:
+#   ./.github/scripts/collect-frontend-stats.sh
+
+STATS_DIR=".github/stats"
+FRONTEND_DIR="frontend"
+mkdir -p "$STATS_DIR"
+
+# Run npm audit (may exit 1 when vulns exist — capture stdout regardless).
+AUDIT_JSON=$(cd "$FRONTEND_DIR" && npm audit --json 2>/dev/null || true)
+
+# Build the stats JSON in a single Node pass so we don't depend on bc/jq.
+AUDIT_JSON="$AUDIT_JSON" node > "$STATS_DIR/frontend.json" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const FRONTEND_DIR = 'frontend';
+const pkg = require(path.resolve(FRONTEND_DIR, 'package.json'));
+const lock = require(path.resolve(FRONTEND_DIR, 'package-lock.json'));
+
+// Lockfile total package count.
+// - lockfileVersion >= 2: flat `packages` map keyed by path; skip the root "" entry.
+// - lockfileVersion 1: walk nested `dependencies` tree.
+function countLockfilePackages(lock) {
+  if (lock.packages) {
+    return Object.keys(lock.packages).filter((k) => k.startsWith('node_modules/')).length;
+  }
+  let total = 0;
+  const walk = (deps) => {
+    if (!deps) return;
+    for (const name of Object.keys(deps)) {
+      total += 1;
+      walk(deps[name].dependencies);
+    }
+  };
+  walk(lock.dependencies);
+  return total;
+}
+
+function dirSize(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let total = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      total += dirSize(p);
+    } else if (entry.isFile()) {
+      try {
+        total += fs.statSync(p).size;
+      } catch {}
+    }
+  }
+  return total;
+}
+
+function humanSize(bytes) {
+  if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + 'G';
+  if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + 'M';
+  if (bytes >= 1024) return (bytes / 1024).toFixed(1) + 'K';
+  return bytes + 'B';
+}
+
+const deps = Object.keys(pkg.dependencies || {}).sort();
+const devDeps = Object.keys(pkg.devDependencies || {}).sort();
+
+const nmBytes = dirSize(path.join(FRONTEND_DIR, 'node_modules'));
+const nextDir = path.join(FRONTEND_DIR, '.next');
+const nextTotal = dirSize(nextDir);
+const nextCache = dirSize(path.join(nextDir, 'cache'));
+const buildBytes = Math.max(0, nextTotal - nextCache);
+
+const emptyVulns = { info: 0, low: 0, moderate: 0, high: 0, critical: 0 };
+let vulns = emptyVulns;
+const auditRaw = process.env.AUDIT_JSON || '';
+if (auditRaw.trim()) {
+  try {
+    const v = JSON.parse(auditRaw).metadata?.vulnerabilities || {};
+    vulns = {
+      info: v.info || 0,
+      low: v.low || 0,
+      moderate: v.moderate || 0,
+      high: v.high || 0,
+      critical: v.critical || 0,
+    };
+  } catch (err) {
+    process.stderr.write(`Warning: failed to parse npm audit JSON: ${err.message}\n`);
+  }
+}
+
+const stats = {
+  packageCount: countLockfilePackages(lock),
+  lockfileVersion: lock.lockfileVersion || 1,
+  dependencyCount: deps.length,
+  devDependencyCount: devDeps.length,
+  dependencies: deps,
+  devDependencies: devDeps,
+  nodeModulesSize: humanSize(nmBytes),
+  nodeModulesSizeBytes: nmBytes,
+  buildSize: humanSize(buildBytes),
+  buildSizeBytes: buildBytes,
+  vulnerabilities: vulns,
+};
+
+process.stdout.write(JSON.stringify(stats, null, 2) + '\n');
+NODE
+
+# Echo a summary to the workflow log.
+node -e "
+  const s = require('./$STATS_DIR/frontend.json');
+  console.log('Frontend stats:');
+  console.log('  ' + s.packageCount + ' total packages in lockfile (v' + s.lockfileVersion + ')');
+  console.log('  ' + s.dependencyCount + ' direct deps + ' + s.devDependencyCount + ' devDeps');
+  console.log('  node_modules: ' + s.nodeModulesSize);
+  console.log('  build (.next minus cache): ' + s.buildSize);
+  const v = s.vulnerabilities;
+  console.log('  vulns: ' + v.critical + ' crit / ' + v.high + ' high / ' + v.moderate + ' mod / ' + v.low + ' low / ' + v.info + ' info');
+"

--- a/.github/scripts/generate-frontend-stats-report.js
+++ b/.github/scripts/generate-frontend-stats-report.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * Generate a markdown report comparing current frontend dependency stats
+ * with a baseline (typically the main branch).
+ *
+ * Usage:
+ *   node generate-frontend-stats-report.js <current-stats-dir> [baseline-stats-dir]
+ *
+ * Each directory should contain frontend.json (produced by collect-frontend-stats.sh).
+ * The report is printed to stdout.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const COMMENT_MARKER = "<!-- frontend-dependency-stats-report -->";
+
+function readStats(dir) {
+  if (!dir) return null;
+  const file = path.join(dir, "frontend.json");
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function formatSize(bytes) {
+  if (!bytes) return "0 KB";
+  const mb = bytes / 1048576;
+  if (mb < 0.1) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${mb.toFixed(1)} MB`;
+}
+
+function diffSize(current, baseline) {
+  const cur = formatSize(current);
+  if (baseline === null || baseline === undefined) return cur;
+  const delta = current - baseline;
+  if (delta === 0) return `${cur} (=)`;
+  const sign = delta > 0 ? "+" : "-";
+  return `${cur} (${sign}${formatSize(Math.abs(delta))})`;
+}
+
+function diffCount(current, baseline) {
+  if (baseline === null || baseline === undefined) return String(current);
+  const delta = current - baseline;
+  if (delta === 0) return `${current} (=)`;
+  const sign = delta > 0 ? "+" : "";
+  return `${current} (${sign}${delta})`;
+}
+
+function vulnTotal(v) {
+  if (!v) return 0;
+  return (v.critical || 0) + (v.high || 0) + (v.moderate || 0) + (v.low || 0) + (v.info || 0);
+}
+
+function formatVulns(current, baseline) {
+  const total = vulnTotal(current);
+  if (total === 0) {
+    if (baseline && vulnTotal(baseline) > 0) {
+      return `0 (-${vulnTotal(baseline)}) ✅`;
+    }
+    return "0 ✅";
+  }
+  const parts = [];
+  if (current.critical) parts.push(`${current.critical} critical`);
+  if (current.high) parts.push(`${current.high} high`);
+  if (current.moderate) parts.push(`${current.moderate} mod`);
+  if (current.low) parts.push(`${current.low} low`);
+  if (current.info) parts.push(`${current.info} info`);
+  let out = parts.join(", ");
+  if (baseline) {
+    const delta = total - vulnTotal(baseline);
+    if (delta !== 0) {
+      out += ` (${delta > 0 ? "+" : ""}${delta})`;
+    }
+  }
+  const icon = current.critical || current.high ? " ⚠️" : current.moderate || current.low ? " ⚠️" : "";
+  return out + icon;
+}
+
+function diffDepList(currentDeps, baselineDeps) {
+  if (!baselineDeps) return { added: [], removed: [] };
+  const cur = new Set(currentDeps);
+  const base = new Set(baselineDeps);
+  return {
+    added: [...cur].filter((d) => !base.has(d)).sort(),
+    removed: [...base].filter((d) => !cur.has(d)).sort(),
+  };
+}
+
+function generate(currentDir, baselineDir) {
+  const current = readStats(currentDir);
+  if (!current) {
+    console.error(`Error: no frontend.json in ${currentDir}`);
+    process.exit(1);
+  }
+  const baseline = readStats(baselineDir);
+  const hasBaseline = baseline !== null;
+
+  let md = `${COMMENT_MARKER}\n`;
+  md += `## Frontend Dependency Stats\n\n`;
+  if (!hasBaseline) {
+    md += `> **Note:** No baseline found. Showing current stats only.\n\n`;
+  }
+
+  md += `| Metric | Value |\n`;
+  md += `|--------|-------|\n`;
+  md += `| Total Packages (lockfile) | ${diffCount(current.packageCount, baseline?.packageCount)} |\n`;
+  md += `| Direct Dependencies | ${diffCount(current.dependencyCount, baseline?.dependencyCount)} |\n`;
+  md += `| Dev Dependencies | ${diffCount(current.devDependencyCount, baseline?.devDependencyCount)} |\n`;
+  md += `| node_modules Size | ${diffSize(current.nodeModulesSizeBytes, baseline?.nodeModulesSizeBytes)} |\n`;
+  md += `| Build Output Size (.next minus cache) | ${diffSize(current.buildSizeBytes, baseline?.buildSizeBytes)} |\n`;
+  md += `| Vulnerabilities | ${formatVulns(current.vulnerabilities, baseline?.vulnerabilities)} |\n`;
+  md += `\n`;
+
+  if (hasBaseline) {
+    const depsDiff = diffDepList(current.dependencies, baseline.dependencies);
+    const devDepsDiff = diffDepList(current.devDependencies, baseline.devDependencies);
+    const hasChanges =
+      depsDiff.added.length || depsDiff.removed.length || devDepsDiff.added.length || devDepsDiff.removed.length;
+
+    if (hasChanges) {
+      md += `### Dependency Changes\n\n`;
+      md += `<details>\n<summary>Click to expand</summary>\n\n`;
+      if (depsDiff.added.length) {
+        md += `**Added dependencies:**\n`;
+        for (const d of depsDiff.added) md += `- \`${d}\`\n`;
+        md += `\n`;
+      }
+      if (depsDiff.removed.length) {
+        md += `**Removed dependencies:**\n`;
+        for (const d of depsDiff.removed) md += `- \`${d}\`\n`;
+        md += `\n`;
+      }
+      if (devDepsDiff.added.length) {
+        md += `**Added devDependencies:**\n`;
+        for (const d of devDepsDiff.added) md += `- \`${d}\`\n`;
+        md += `\n`;
+      }
+      if (devDepsDiff.removed.length) {
+        md += `**Removed devDependencies:**\n`;
+        for (const d of devDepsDiff.removed) md += `- \`${d}\`\n`;
+        md += `\n`;
+      }
+      md += `</details>\n\n`;
+    }
+  }
+
+  md += `---\n*Generated at ${new Date().toISOString()}*\n`;
+  return md;
+}
+
+const [currentDir, baselineDir] = process.argv.slice(2);
+if (!currentDir) {
+  console.error("Usage: node generate-frontend-stats-report.js <current-stats-dir> [baseline-stats-dir]");
+  process.exit(1);
+}
+process.stdout.write(generate(currentDir, baselineDir || null));

--- a/.github/workflows/frontend-dependency-stats.yml
+++ b/.github/workflows/frontend-dependency-stats.yml
@@ -1,0 +1,110 @@
+name: Frontend Dependency Stats
+
+on:
+  pull_request:
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-dependency-stats.yml
+      - .github/scripts/collect-frontend-stats.sh
+      - .github/scripts/generate-frontend-stats-report.js
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-dependency-stats.yml
+      - .github/scripts/collect-frontend-stats.sh
+      - .github/scripts/generate-frontend-stats-report.js
+  workflow_dispatch:
+
+jobs:
+  stats:
+    name: Collect & report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "16.x"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+        working-directory: ./frontend
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v3
+        with:
+          path: frontend/.next/cache
+          key: ${{ runner.os }}-frontend-stats-nextcache-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-stats-nextcache-
+
+      - name: Build
+        run: npm run build
+        working-directory: ./frontend
+
+      - name: Collect stats
+        run: |
+          chmod +x .github/scripts/collect-frontend-stats.sh
+          .github/scripts/collect-frontend-stats.sh
+
+      - name: Upload stats artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dependency-stats-${{ github.ref_name }}
+          path: .github/stats/frontend.json
+          retention-days: 30
+
+      - name: Download baseline stats (PR only)
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: frontend-dependency-stats.yml
+          branch: ${{ github.event.pull_request.base.ref }}
+          name: frontend-dependency-stats-${{ github.event.pull_request.base.ref }}
+          path: stats-baseline
+          if_no_artifact_found: warn
+
+      - name: Generate report
+        id: report
+        run: |
+          mkdir -p stats-current
+          cp .github/stats/frontend.json stats-current/frontend.json
+          if [ -f "stats-baseline/frontend.json" ]; then
+            node .github/scripts/generate-frontend-stats-report.js stats-current stats-baseline > report.md
+          else
+            node .github/scripts/generate-frontend-stats-report.js stats-current > report.md
+          fi
+          {
+            echo "report<<REPORT_EOF"
+            cat report.md
+            echo "REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- frontend-dependency-stats-report -->"
+
+      - name: Create or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.report.outputs.report }}
+          edit-mode: replace

--- a/.github/workflows/frontend-dependency-stats.yml
+++ b/.github/workflows/frontend-dependency-stats.yml
@@ -58,7 +58,8 @@ jobs:
           chmod +x .github/scripts/collect-frontend-stats.sh
           .github/scripts/collect-frontend-stats.sh
 
-      - name: Upload stats artifact
+      - name: Upload baseline stats (push to main only)
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-dependency-stats-${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Adds a new `Frontend Dependency Stats` workflow that runs on PRs touching `frontend/**` and on pushes to `main`.
- Collects lockfile package count, direct/dev dependency counts, `node_modules` size, Next.js build size (`.next` minus `.next/cache`), and `npm audit` vulnerability counts into `.github/stats/frontend.json`.
- On `main`, uploads the stats as an artifact; on PRs, downloads the latest `main` artifact via `dawidd6/action-download-artifact@v6` and posts/updates a PR comment with the diff (added/removed deps included).

## Test plan
- [ ] Workflow run on this PR completes the `Collect & report` job successfully.
- [ ] First-time run posts a comment marked with `<!-- frontend-dependency-stats-report -->` (no baseline note expected until the workflow has run on `main`).
- [ ] After merge, a subsequent PR shows a real diff (sizes, vulns, dep changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)