### PR TITLE
ci: fix invalid with: block on bundle-analysis Analyze step

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -42,8 +42,7 @@ jobs:
       # This step pulls the raw bundle stats for the current bundle
       - name: Analyze bundle
         run: npx -p nextjs-bundle-analysis report
-        with:
-          working-directory: ./frontend
+        working-directory: ./frontend
 
       - name: Upload bundle
         uses: actions/upload-artifact@v2

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: frontend/.next/analyze/__bundle_analysis.json


### PR DESCRIPTION
## Summary
- Fix `Analyze bundle` step in `.github/workflows/nextjs-bundle-analysis.yml` which combined `run:` and `with:` — invalid GitHub Actions syntax (`with:` only goes with `uses:`). The workflow failed to parse, so no jobs ever ran (15 runs / 0 successes since the file was created). The npm migration (#919) fixed the same bug on the build step above but missed this one.
- Bump `actions/upload-artifact` from v2 to v4. v1, v2, and v3 are all deprecated and hard-fail (see deprecation notices for [v1/v2](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) and [v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)) — surfaced once the workflow could finally parse and run.

## Test plan
- [ ] CI run on this PR actually executes the `analyze` job (instead of failing instantly with "workflow file issue")
- [ ] Upload bundle step succeeds (no deprecation hard-fail)
- [ ] Bundle analysis comment is posted on the PR