### PR TITLE
ci: disable buggy react/no-unknown-property rule

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -26,6 +26,7 @@
     "@typescript-eslint/ban-ts-comment": 1,
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,
+    "react/no-unknown-property": 0,
     "jsx-a11y/anchor-is-valid": [
       "error",
       {


### PR DESCRIPTION
## Summary

The Next.js Bundle Analysis workflow was failing on every PR with two ESLint errors:

- `pages/_document.tsx:17` — `Unknown property 'as' found` on `<link>`
- `components/pages/BuildPage/glow.component.tsx` — `Invalid property 'fill' found on tag 'ellipse'` (×3)

Both are valid attributes. `eslint-plugin-react@7.31.4` (pinned in lockfile) has an incomplete SVG/HTML attribute whitelist in `react/no-unknown-property`; the rule was overhauled in 7.32+.

The Docker `build-and-push` workflow didn't catch this because its buildx layer cache short-circuits `npm run build`, so it never actually re-runs `next build`.

Disable the rule for now. Re-enable once `eslint-plugin-react` is bumped.

## Test plan

- [ ] Bundle analysis workflow passes on this PR