### PR TITLE
ci: fix bundle-analysis download + compare steps

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -51,7 +51,7 @@ jobs:
           path: frontend/.next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         if: success() && github.event.number
         with:
           workflow: nextjs-bundle-analysis.yml

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -73,7 +73,8 @@ jobs:
       # entry in your package.json file.
       - name: Compare with base branch bundle
         if: success() && github.event.number
-        run: ls -laR frontend/.next/analyze/base && npx -p nextjs-bundle-analysis compare
+        run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
+        working-directory: ./frontend
 
       - name: Get comment body
         id: get-comment-body


### PR DESCRIPTION
## Summary
Two fixes to get `Next.js Bundle Analysis` working end-to-end:

1. **Bump `dawidd6/action-download-artifact` v2 → v6.** With `actions/upload-artifact@v4` (bumped in bf184ffc) uploads use GitHub's new artifacts API; v2 of the downloader can't read v4 artifacts and the step failed with `no matching workflow run found with any artifacts?` even when a successful base run existed.
2. **Run the `Compare with base branch bundle` step in `./frontend`.** It was running from repo root and failing with `Cannot find module '.../package.json'` — `nextjs-bundle-analysis` reads `./package.json` from cwd, which lives under `frontend/`.

## Verification
Last CI run on this branch (25948199323) is fully green — `Download base branch bundle stats`, `Compare with base branch bundle`, and `Create Comment` all succeeded and the bundle-size diff comment posted on this PR.

## Test plan
- [x] `analyze` job passes end-to-end on this PR
- [x] Bundle-size diff comment is created on the PR