### PR TITLE
ci: run Playwright E2E suite against the docker-compose stack

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -154,12 +154,104 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.ref.name=${{ github.ref }}
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IMAGE_REPO: ${{ github.repository }}
+      IMAGE_TAG: 1.0.0-ci${{ github.run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate dev TLS certificate
+        # docker-compose mounts .local/dev-certificate.pfx into the api +
+        # identity containers as their data-protection key. Generate a throwaway
+        # one for CI — never committed to the repo.
+        run: |
+          cd .local
+          bash ../scripts/generate-certificate.sh
+          mv certificate.pfx dev-certificate.pfx
+
+      - name: Map local.factorio.tech hostnames to localhost
+        run: |
+          echo "127.0.0.1 local.factorio.tech api.local.factorio.tech identity.local.factorio.tech" \
+            | sudo tee -a /etc/hosts
+
+      - name: Start stack
+        run: |
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yaml up -d
+
+      - name: Wait for API to be seeded
+        # Poll the test fixture's own endpoint — a 200 here proves both that
+        # the API is up AND that DevDataSeeder ran successfully. A bare /builds
+        # check would pass with an empty list if the seed gist fetch silently
+        # failed (the seeder logs and returns rather than throwing).
+        run: |
+          for i in $(seq 1 60); do
+            if curl -ksfo /dev/null https://api.local.factorio.tech/builds/brian-white/brians-bootstrap; then
+              echo "API seeded after ${i} attempts"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::API did not seed within 5 minutes"
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yaml logs --tail=200 api identity
+          exit 1
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        env:
+          E2E_BASE_URL: https://local.factorio.tech
+          NODE_TLS_REJECT_UNAUTHORIZED: "0"
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yaml -f docker-compose.ci.yaml logs --tail=500
+
   deploy:
     environment:
       name: staging
       url: https://factorio.tech
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs:
+      - build-and-push
+      - e2e
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,0 +1,36 @@
+# CI override for E2E. Pairs with docker-compose.yaml:
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.ci.yaml up -d
+#
+# - Pulls pre-built api/identity/web from GHCR instead of building from source.
+#   IMAGE_TAG defaults to "ci" (latest main); the e2e job overrides it to the
+#   version tag pushed by the same workflow run so we test the PR's images.
+# - Disables fbsr — runtime needs a Factorio install we can't ship to CI. The
+#   tested pages render text/metadata; <img> tags pointing at the rendering
+#   endpoint will 500 but don't fail the assertions.
+
+services:
+  web:
+    build: !reset null
+    image: ghcr.io/${IMAGE_REPO:-factorio-builds/factorio-builds-tech}/web:${IMAGE_TAG:-ci}
+    pull_policy: always
+
+  identity:
+    build: !reset null
+    image: ghcr.io/${IMAGE_REPO:-factorio-builds/factorio-builds-tech}/identity:${IMAGE_TAG:-ci}
+    pull_policy: always
+
+  api:
+    build: !reset null
+    image: ghcr.io/${IMAGE_REPO:-factorio-builds/factorio-builds-tech}/api:${IMAGE_TAG:-ci}
+    pull_policy: always
+    # !override (not the default !merge) so fbsr — disabled below — is dropped
+    # from the union'd dependency list. Without this, Compose complains about
+    # an "undefined service fbsr".
+    depends_on: !override
+      - traefik
+      - postgres
+      - identity
+
+  fbsr:
+    profiles: ["disabled"]


### PR DESCRIPTION
## Summary
- Adds an `e2e` job to `build-and-push.yml` that runs after the image build and gates `deploy`.
- Pulls the freshly-pushed `:1.0.0-ci<run_id>` images for `web`/`identity`/`api` (no rebuild), brings up the stack via a new `docker-compose.ci.yaml` override, polls `/builds` until `DevDataSeeder` has populated `brian-white`, then runs `npm run test:e2e` against `https://local.factorio.tech`.
- `fbsr` is excluded via a `disabled` compose profile — its runtime needs a Factorio install we can't ship to CI. The tested pages render text/metadata fine; only the `<img>` rendering endpoint will 500, and no spec asserts on it.

## Test plan
- [ ] First CI run on this PR: confirm `e2e` job runs after `build-and-push`, the stack boots, the seeder finishes, and Playwright reports 13 passed + 1 fixme (matching local).
- [ ] If anything fails, iterate based on the uploaded `playwright-report` artifact + the compose-logs-on-failure step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)