### PR TITLE
chore(frontend): wire App Insights through the official React plugin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@artsy/fresnel": "^6.1.0",
+        "@microsoft/applicationinsights-react-js": "^18.3.6",
         "@microsoft/applicationinsights-web": "^3.4.1",
         "@react-aria/button": "^3.15.0",
         "@react-aria/checkbox": "^3.17.0",
@@ -784,6 +785,21 @@
         "tslib": ">= 1.0.0"
       }
     },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-core-js": {
       "version": "3.4.1",
       "license": "MIT",
@@ -822,6 +838,24 @@
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-react-js": {
+      "version": "18.3.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-18.3.6.tgz",
+      "integrity": "sha512-MQnMFi4kgIT0YV9l3nMfYbTJQBWEhAsuVvbJVSmDRL15pad1vT+VflNenN5nY7AYDf3UeMWyA1Bnv6QhIczB/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "^3.3.6",
+        "@microsoft/applicationinsights-core-js": "^3.3.6",
+        "@microsoft/applicationinsights-shims": "^3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+      },
+      "peerDependencies": {
+        "history": ">= 4.10.1",
+        "react": ">= 18.0.0",
+        "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-shims": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@artsy/fresnel": "^6.1.0",
+    "@microsoft/applicationinsights-react-js": "^18.3.6",
     "@microsoft/applicationinsights-web": "^3.4.1",
     "@react-aria/button": "^3.15.0",
     "@react-aria/checkbox": "^3.17.0",

--- a/frontend/src/lib/appInsights.ts
+++ b/frontend/src/lib/appInsights.ts
@@ -1,6 +1,7 @@
-// Replaces the unmaintained `next-applicationinsights` wrapper. Loaded
-// client-side only; gated by ENABLE_APPLICATION_INSIGHTS env at the call site.
 import { ApplicationInsights } from "@microsoft/applicationinsights-web"
+import { ReactPlugin } from "@microsoft/applicationinsights-react-js"
+
+export const reactPlugin = new ReactPlugin()
 
 let initialized = false
 
@@ -14,6 +15,7 @@ export function initAppInsights(instrumentationKey?: string): void {
       instrumentationKey,
       enableAutoRouteTracking: true,
       autoTrackPageVisitTime: true,
+      extensions: [reactPlugin],
     },
   })
   appInsights.loadAppInsights()

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -12,7 +12,8 @@ import { getCssText, globalStyles } from "../design/stitches.config"
 import { mediaStyles, MediaContextProvider } from "../design/styles/media"
 import { makeStore } from "../redux/store"
 import { publicRuntimeConfig } from "../utils/config"
-import { initAppInsights } from "../lib/appInsights"
+import { AppInsightsContext } from "@microsoft/applicationinsights-react-js"
+import { initAppInsights, reactPlugin } from "../lib/appInsights"
 
 // Inject the static global styles into Stitches' registry at module load so
 // getCssText() picks them up on first render.
@@ -54,13 +55,15 @@ function RootComponent() {
 
   return (
     <RootDocument>
-      <ReduxProvider store={store}>
-        <MediaContextProvider disableDynamicMediaQueries>
-          <SSRProvider>
-            <Outlet />
-          </SSRProvider>
-        </MediaContextProvider>
-      </ReduxProvider>
+      <AppInsightsContext.Provider value={reactPlugin}>
+        <ReduxProvider store={store}>
+          <MediaContextProvider disableDynamicMediaQueries>
+            <SSRProvider>
+              <Outlet />
+            </SSRProvider>
+          </MediaContextProvider>
+        </ReduxProvider>
+      </AppInsightsContext.Provider>
     </RootDocument>
   )
 }


### PR DESCRIPTION
## Summary

Completes spike **C1** from the FE dep audit. The `migrate-to-tanstack-start` work already dropped the unmaintained `next-applicationinsights` wrapper in favour of `@microsoft/applicationinsights-web`; this PR layers the official `@microsoft/applicationinsights-react-js` (^18.3.6) on top so descendants can use `useAppInsightsContext` / `useTrackEvent` / `withAITracking`. A `ReactPlugin` is instantiated in `src/lib/appInsights.ts`, passed via `extensions: [reactPlugin]` to the SDK init, and exposed at the route root through `AppInsightsContext.Provider`. SPA route tracking still flows through the core SDK's `enableAutoRouteTracking`, so no TanStack-Router-specific binding is needed.

## Test plan

- [x] `npm run build` (vite) succeeds
- [ ] Smoke check in browser with `ENABLE_APPLICATION_INSIGHTS=true` + a valid key — verify a pageview lands in App Insights and `useAppInsightsContext()` returns the plugin in a child component
- [ ] Confirm no telemetry regression when the env flag is off (provider is a no-op without `initAppInsights` being called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)