### PR TITLE
chore(backend): upgrade to .NET 10

### DIFF
--- a/backend/.config/dotnet-tools.json
+++ b/backend/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "6.0.8",
+      "version": "10.0.8",
       "commands": [
         "dotnet-ef"
       ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /app
 
@@ -42,7 +42,7 @@ RUN dotnet build --no-restore --configuration Release /p:DebugType=None \
 ENTRYPOINT [ "dotnet" ]
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 as identity
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 as identity
 ENV ASPNETCORE_URLS=http://*:8080
 EXPOSE 8080
 WORKDIR /app
@@ -50,7 +50,7 @@ COPY --from=build /app/publish/identity .
 ENTRYPOINT [ "dotnet", "FactorioTech.Identity.dll" ]
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 as api
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 as api
 ENV ASPNETCORE_URLS=http://*:8080
 EXPOSE 8080
 WORKDIR /app

--- a/backend/src/FactorioTech.Api/FactorioTech.Api.csproj
+++ b/backend/src/FactorioTech.Api/FactorioTech.Api.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="3.2.3">
+    <PackageReference Include="AutoConstructor" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.8" />
-    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.2" />
     <PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="2.0.2" />

--- a/backend/src/FactorioTech.Api/Startup.cs
+++ b/backend/src/FactorioTech.Api/Startup.cs
@@ -41,7 +41,7 @@ public class Startup
         var appConfig = configuration.GetSection(nameof(AppConfig)).Get<AppConfig>() ?? new AppConfig();
         services.AddSingleton(Options.Create(appConfig));
 
-        services.AddProblemDetails();
+        Hellang.Middleware.ProblemDetails.ProblemDetailsExtensions.AddProblemDetails(services);
         services.AddHttpClient();
         services.AddControllers().AddJsonOptions(options =>
         {

--- a/backend/src/FactorioTech.Core/Data/Migrations/20260516005009_EfCore10ModelSync.Designer.cs
+++ b/backend/src/FactorioTech.Core/Data/Migrations/20260516005009_EfCore10ModelSync.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FactorioTech.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,11 @@ using NpgsqlTypes;
 namespace FactorioTech.Core.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516005009_EfCore10ModelSync")]
+    partial class EfCore10ModelSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FactorioTech.Core/Data/Migrations/20260516005009_EfCore10ModelSync.cs
+++ b/backend/src/FactorioTech.Core/Data/Migrations/20260516005009_EfCore10ModelSync.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FactorioTech.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class EfCore10ModelSync : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                schema: "identity",
+                table: "ServerSideSession",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.CreateTable(
+                name: "PushedAuthorizationRequests",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ReferenceValueHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Parameters = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PushedAuthorizationRequests", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushedAuthorizationRequests_ExpiresAtUtc",
+                schema: "identity",
+                table: "PushedAuthorizationRequests",
+                column: "ExpiresAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushedAuthorizationRequests_ReferenceValueHash",
+                schema: "identity",
+                table: "PushedAuthorizationRequests",
+                column: "ReferenceValueHash",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PushedAuthorizationRequests",
+                schema: "identity");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                schema: "identity",
+                table: "ServerSideSession",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+    }
+}

--- a/backend/src/FactorioTech.Core/Data/PersistedGrantIdentityContext.cs
+++ b/backend/src/FactorioTech.Core/Data/PersistedGrantIdentityContext.cs
@@ -16,6 +16,7 @@ public class PersistedGrantIdentityContext : IdentityDbContext<User, Role, Guid>
     public DbSet<DeviceFlowCodes> DeviceFlowCodes { get; set; } = null!;
     public DbSet<ServerSideSession> ServerSideSessions { get; set; } = null!;
     public DbSet<Key> Keys { get; set; } = null!;
+    public DbSet<PushedAuthorizationRequest> PushedAuthorizationRequests { get; set; } = null!;
 
     private const string IdentitySchema = "identity";
     private readonly IOptions<OperationalStoreOptions> operationalStoreOptions;
@@ -67,6 +68,7 @@ public class PersistedGrantIdentityContext : IdentityDbContext<User, Role, Guid>
                 Id = Guid.Parse("52a39ea9-ab54-40ab-8ee0-98c069504f69"),
                 Name = "Moderator",
                 NormalizedName = "MODERATOR",
+                ConcurrencyStamp = "bc16f20d-e7b6-483f-a4da-25909c39ff44",
             });
 
             entity.HasData(new Role
@@ -74,6 +76,7 @@ public class PersistedGrantIdentityContext : IdentityDbContext<User, Role, Guid>
                 Id = Guid.Parse("3d15ca3a-584e-4d30-94df-b43d2303a4f4"),
                 Name = "Administrator",
                 NormalizedName = "ADMINISTRATOR",
+                ConcurrencyStamp = "b770c2f0-f26f-4519-81ba-76965982ae17",
             });
         });
 
@@ -91,5 +94,6 @@ public class PersistedGrantIdentityContext : IdentityDbContext<User, Role, Guid>
         builder.Entity<DeviceFlowCodes>().ToTable(nameof(DeviceFlowCodes), IdentitySchema);
         builder.Entity<ServerSideSession>().ToTable(nameof(ServerSideSession), IdentitySchema);
         builder.Entity<Key>().ToTable(nameof(Keys), IdentitySchema);
+        builder.Entity<PushedAuthorizationRequest>().ToTable(nameof(PushedAuthorizationRequests), IdentitySchema);
     }
 }

--- a/backend/src/FactorioTech.Core/FactorioTech.Core.csproj
+++ b/backend/src/FactorioTech.Core/FactorioTech.Core.csproj
@@ -1,32 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="3.2.3">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoConstructor" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-    <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="6.1.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="7.4.7" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nanoid" Version="2.1.0" />
-    <PackageReference Include="NodaTime" Version="3.1.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="6.0.6" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Nanoid" Version="3.1.0" />
+    <PackageReference Include="NodaTime" Version="3.3.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/FactorioTech.Core/IdentityExtensions.cs
+++ b/backend/src/FactorioTech.Core/IdentityExtensions.cs
@@ -1,5 +1,5 @@
 using FactorioTech.Core.Domain;
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Security.Claims;
 
 namespace FactorioTech.Core;

--- a/backend/src/FactorioTech.Core/Services/ImageService.cs
+++ b/backend/src/FactorioTech.Core/Services/ImageService.cs
@@ -171,7 +171,7 @@ public partial class ImageService
                 .Resize(resize));
         }
 
-        var imageId = await Nanoid.Nanoid.GenerateAsync("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        var imageId = await NanoidDotNet.Nanoid.GenerateAsync("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
         var containerClient = blobServiceClient.GetBlobContainerClient(AppConfig.StorageContainers.Data);
         await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
 

--- a/backend/src/FactorioTech.Identity/Configuration/IdentityConfig.cs
+++ b/backend/src/FactorioTech.Identity/Configuration/IdentityConfig.cs
@@ -1,7 +1,7 @@
 using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using FactorioTech.Core;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace FactorioTech.Identity.Configuration;
 

--- a/backend/src/FactorioTech.Identity/FactorioTech.Identity.csproj
+++ b/backend/src/FactorioTech.Identity/FactorioTech.Identity.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="3.2.3">
+    <PackageReference Include="AutoConstructor" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="6.0.9" />
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.9" />
-    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="6.1.4" />
-    <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="6.1.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.8" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="10.0.0" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
+    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.7" />
+    <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.4.7" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="SluggyUnidecode" Version="2.0.1" />
   </ItemGroup>

--- a/backend/test/FactorioTech.Tests/BuildsServiceTests.cs
+++ b/backend/test/FactorioTech.Tests/BuildsServiceTests.cs
@@ -1,6 +1,3 @@
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
-using DotNet.Testcontainers.Containers;
 using FactorioTech.Core.Data;
 using FactorioTech.Core.Domain;
 using FactorioTech.Core.Services;
@@ -8,6 +5,7 @@ using FactorioTech.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace FactorioTech.Tests;
@@ -15,22 +13,20 @@ namespace FactorioTech.Tests;
 public class BuildsServiceTests : IAsyncLifetime
 {
     private AppDbContext dbContext = null!;
-    private PostgreSqlTestcontainer postgresContainer = null!;
+    private PostgreSqlContainer postgresContainer = null!;
     private BuildService service = null!;
 
     public async Task InitializeAsync()
     {
-        postgresContainer = new TestcontainersBuilder<PostgreSqlTestcontainer>()
-            .WithDatabase(new PostgreSqlTestcontainerConfiguration("postgres:latest")
-            {
-                Database = "postgres",
-                Username = "postgres",
-                Password = "postgres",
-            }).Build();
+        postgresContainer = new PostgreSqlBuilder("postgres:latest")
+            .WithDatabase("postgres")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .Build();
 
         await postgresContainer.StartAsync();
 
-        dbContext = AppDbContextFactory.CreateDbContext(postgresContainer.ConnectionString);
+        dbContext = AppDbContextFactory.CreateDbContext(postgresContainer.GetConnectionString());
         await dbContext.Database.MigrateAsync();
 
         service = new BuildService(new NullLogger<BuildService>(), dbContext, TestUtils.Tags.Value);
@@ -39,8 +35,6 @@ public class BuildsServiceTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await dbContext.DisposeAsync();
-        await postgresContainer.StopAsync();
-        await postgresContainer.CleanUpAsync();
         await postgresContainer.DisposeAsync();
     }
 

--- a/backend/test/FactorioTech.Tests/FactorioTech.Tests.csproj
+++ b/backend/test/FactorioTech.Tests/FactorioTech.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="Testcontainers" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Upgrades the entire backend from **.NET 6** to **.NET 10**, bumps framework-tied and stale packages, and applies the code/schema changes the jump forces. Build is clean, all 17 tests pass (11 unit + 6 Testcontainers integration), and both `Api` and `Identity` publish.

## Framework + tooling
- All 4 csproj: `net6.0` → `net10.0`
- `Dockerfile`: `sdk:6.0` / `aspnet:6.0` → `10.0`
- `dotnet-ef` tool `6.0.8` → `10.0.8`

## Package bumps
**Framework-tied (→ 10.x)**
- `Microsoft.AspNetCore.*`, `EntityFrameworkCore.Tools` + new `EntityFrameworkCore.Design` 10.0.8 pin (Duende transitively pulled EF Design 8.0, which broke `dotnet ef`)
- `AspNet.Security.OAuth.Discord` / `.GitHub` 10.0.0, `Serilog.AspNetCore` 10.0.0
- `Npgsql.EntityFrameworkCore.PostgreSQL` + `.NodaTime` 10.0.1

**Latest stable, no license change**
- `AutoConstructor` 5.6.0, `Azure.Storage.Blobs` 12.28.0, `NodaTime` 3.3.2 + `Serialization.SystemTextJson` 1.3.1, `SharpZipLib` 1.4.2, `Nanoid` 3.1.0, `ApplicationInsights[.AspNetCore]` 2.23.0 (kept v2), test deps (xunit 2.9.3, runner.visualstudio 3.1.5, NET.Test.Sdk 18.5.1, NSubstitute 5.3.0, Testcontainers.PostgreSql 4.11.0)

**Forced major bump**
- `Duende.IdentityServer.*` 6.1.4 → **7.4.7** — won't compose with .NET 10 otherwise

## Code / schema changes the upgrade forced
- `IdentityExtensions` / `IdentityConfig`: `IdentityModel` → `Duende.IdentityModel`
- `PersistedGrantIdentityContext`: add `PushedAuthorizationRequests` DbSet (Duende v7); hardcode `ConcurrencyStamp` on `Role` seeds so the model is deterministic (EF 10 throws where EF 6 only warned)
- `ImageService`: `Nanoid.Nanoid` → `NanoidDotNet.Nanoid` (v3)
- `Startup`: fully-qualify the Hellang `AddProblemDetails` call (disambiguate from the built-in one added in .NET 7+)
- `BuildsServiceTests`: rewritten for the Testcontainers v4 fluent API
- Removed `Microsoft.AspNetCore.Http.Abstractions` package → `FrameworkReference Microsoft.AspNetCore.App` in Core
- New migration `20260516005009_EfCore10ModelSync`: `identity.ServerSideSession.Id` `integer` → `bigint`, new `identity.PushedAuthorizationRequests` table

## ⚠️ Things to weigh before merging
1. **Duende license** — the v7 bump was forced by the .NET 10 jump. Community Edition still applies; if usage exceeds its threshold that's a real cost. Alternative: migrate Identity to OpenIddict (Apache 2.0) as a follow-up.
2. **Held back to avoid commercial licenses** — `SixLabors.ImageSharp` 2.1.13 (v3+ = Split License), `ImageSharp.Web` / `.Providers.Azure` left at 2.0.2 (no newer Apache release exists), `FluentAssertions` 7.2.2 (v8 is commercial).
3. **`ApplicationInsights` kept on v2** — v3 has a breaking telemetry-pipeline API; separate scoped upgrade.
4. **Migration locks** — `ServerSideSession.Id integer → bigint` does a column rewrite (`ACCESS EXCLUSIVE` lock). Small auth table, but if `identity.ServerSideSession` is large, deploy during a maintenance window.

## Follow-ups (out of scope)
- Migrate off `Hellang.Middleware.ProblemDetails` (2022) to the built-in `AddProblemDetails`/`UseProblemDetails` — blocked on controller `[ProducesResponseType(typeof(ProblemDetails), …)]` annotations.
- Swashbuckle 6.4.0 → built-in `Microsoft.AspNetCore.OpenApi` (.NET 9+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)